### PR TITLE
CSS Fixes in Panel

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -104,10 +104,12 @@
   text-align: left;
   line-height: 1.3em;
   color: #000;
-  white-space: nowrap;
-  margin: 0 5px;
-  
+  margin: 0 5px;  
   padding: 5px 0;
+}
+
+.adp-info-header {
+	font-weight: bold;
 }
 
 .adp-panel-footer {

--- a/src/js/player/PrivacyInfo.js
+++ b/src/js/player/PrivacyInfo.js
@@ -119,7 +119,7 @@ $ADP.PrivacyInfo.prototype = {
       if (url) s = '<a href="' + url + '" target="_blank">' + s + '</a>';
       if (s) s += '<br />';
       if (text) s = text + '<br />' + s;
-      if (title) s = title + '<br />' + s;
+      if (title) s = '<div class="adp-info-header">' + title + '</div>' + s;
       return s;
     }
 


### PR DESCRIPTION
Removed white-space:nowrap from .adp-info-panel and added div wrapper to privacy title for styling.

See: http://rolloutadplayer.de/wordpress/gforums/topic/adplayer-version-1-5-2-long-privacy-info
