### PR TITLE
Edited style to override background images in popup.

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,7 +1,7 @@
 body.adp-popup {
   margin:0;
   padding:10px;
-  background-color: #FFFFFF;
+  background: #FFFFFF;
   color: #000000;
 }
 


### PR DESCRIPTION
While creating the content HTML of the popup window, the script adds all stylesheets from the parent window to the DOM of the popup. I corrected the adplayer stylesheet to override the background image configuration.

So an background image which is used by the parent website will not appear within the popup anymore.
