### PR TITLE
Create short version of copyright to reduce file size of output resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Build folder
+build/
+
+# Idea configs
+*.iml
+.idea/

--- a/README
+++ b/README
@@ -14,12 +14,19 @@ Importing AdPlayer Project into Eclipse
 5) Project should be imported to current workspace
 
 
-Building AdPlayer Project
+Building AdPlayer Project in Eclipse
 -----------------------------------------
 1) Right click "build.xml" > Run As > Ant Build
 2) A new "build" directory will be created containing the Ant build output.
 3) Note: Eclipse may require you to refresh the project folder's view. This can
    be done easily by right clicking the project folder and clicking "Refresh."
+
+Building AdPlayer Project with Terminal
+-----------------------------------------
+1) Open terminal
+2) navigate into project folder
+3) execute command 'ant'
+4) 'BUILD SUCCESSFUL' should return
 
 Demo Test
 ------------------------------------------

--- a/build.xml
+++ b/build.xml
@@ -95,8 +95,12 @@
 
   <target name="gnu" depends="compress" description="Appends GPL liscense to all build files.">
     <copy tofile="${build-dir}/gpl.txt" file="gpl.txt" overwrite="true" />
-    <copy todir="${build-dir}/tmp" file="gnu.txt" overwrite="true" />
-    <replace file="${build-dir}/tmp/gnu.txt" token="_@VERSION@_" value="${version-detailed}" />
+
+    <copy todir="${build-dir}" file="gnu.txt" overwrite="true" />
+    <replace file="${build-dir}/gnu.txt" token="_@VERSION@_" value="${version-detailed}" />
+
+    <copy todir="${build-dir}/tmp" file="copyright-banner.txt" overwrite="true" />
+    <replace file="${build-dir}/tmp/copyright-banner.txt" token="_@VERSION@_" value="${version-detailed}" />
     
     <!-- TODO: Possibly loop through files, but will require ant-contrib -->
 
@@ -124,18 +128,18 @@
 <!--    </antcall> -->
 
     <!-- HTML Files -->
-    <replace file="${build-dir}/tmp/gnu.txt" token="/*" value="&lt;!--" />
-    <replace file="${build-dir}/tmp/gnu.txt" token="*/" value="--&gt;" />
-    <loadfile property="gnulicense" srcfile="${build-dir}/tmp/gnu.txt" />
+    <replace file="${build-dir}/tmp/copyright-banner.txt" token="/*" value="&lt;!--" />
+    <replace file="${build-dir}/tmp/copyright-banner.txt" token="*/" value="--&gt;" />
+    <loadfile property="gnulicense" srcfile="${build-dir}/tmp/copyright-banner.txt" />
     <replace dir="${build-dir}" token="&lt;!--_@GNULICENSE@_--&gt;" value="${gnulicense}" />
   </target>
 
   <target name="gnu.me">
-    <concat destfile="${build-dir}/tmp/gnutemp.tmp" fixlastline="true">
-      <header filtering="no" trimleading="no" file="${build-dir}/tmp/gnu.txt"></header>
+    <concat destfile="${build-dir}/tmp/concated-file.tmp" fixlastline="true">
+      <header filtering="no" trimleading="no" file="${build-dir}/tmp/copyright-banner.txt"></header>
       <path path="${filepath}"/>
     </concat>
-    <move overwrite="true" file="${build-dir}/tmp/gnutemp.tmp" tofile="${filepath}"></move>
+    <move overwrite="true" file="${build-dir}/tmp/concated-file.tmp" tofile="${filepath}"></move>
   </target>
 
   <target name="_default-build" depends="gnu" description="Processes default and cleans up all temp files.">

--- a/copyright-banner.txt
+++ b/copyright-banner.txt
@@ -1,1 +1,1 @@
-/*! AdPlayer _@VERSION@_ | (c) ADITION Technologies and other contributors | GNU General Public License http://www.gnu.org/licenses/ */
+/*! AdPlayer _@VERSION@_ | Authors: ADTECH, SevenOne Media, Bauer Media, Adition, raumobil | GNU General Public License http://www.gnu.org/licenses/ */

--- a/copyright-banner.txt
+++ b/copyright-banner.txt
@@ -1,0 +1,1 @@
+/*! AdPlayer _@VERSION@_ | (c) ADITION Technologies and other contributors | GNU General Public License http://www.gnu.org/licenses/ */


### PR DESCRIPTION
Reason for this adjustment: our tools for pagespeed and code analysis compain about the output resources of the adplayer. E.g.: Googles pagesspeed tool classifies the adplayer.min.css as **not** minified. Here the licence that is written in the long comment section in the file's preface is not in a appropriate style for the minified version. Thus, we created a short copyright version (in consultation with the former project lead Dennis R.).
